### PR TITLE
AArch64 support

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = step-cli-bin
 	pkgdesc = A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.
-	pkgver = 0.14.4
+	pkgver = 0.14.5
 	pkgrel = 1
 	url = https://smallstep.com/cli
 	arch = x86_64
 	license = Apache
-	source = https://github.com/smallstep/cli/releases/download/v0.14.4/step_linux_0.14.4_amd64.tar.gz
-	source = https://github.com/smallstep/cli/raw/v0.14.4/autocomplete/bash_autocomplete
-	source = https://github.com/smallstep/cli/raw/v0.14.4/autocomplete/zsh_autocomplete
-	sha256sums = 583dd45d16a28f40f9d518bd84d1863ed849c70a4a1f4e89a793a48add107370
+	source = https://github.com/smallstep/cli/releases/download/v0.14.5/step_linux_0.14.5_amd64.tar.gz
+	source = https://github.com/smallstep/cli/raw/v0.14.5/autocomplete/bash_autocomplete
+	source = https://github.com/smallstep/cli/raw/v0.14.5/autocomplete/zsh_autocomplete
+	sha256sums = 4633754ad6b09c87e3e6b82ff01e80b3463059bf6aba6bf7dadc3d5da550dfe1
 	sha256sums = add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be
 	sha256sums = 3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = step-cli-bin
 	pkgdesc = A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.
-	pkgver = 0.14.3
+	pkgver = 0.14.4
 	pkgrel = 1
 	url = https://smallstep.com/cli
 	arch = x86_64
 	license = Apache
-	source = https://github.com/smallstep/cli/releases/download/v0.14.3/step_linux_0.14.3_amd64.tar.gz
-	source = https://github.com/smallstep/cli/raw/v0.14.3/autocomplete/bash_autocomplete
-	source = https://github.com/smallstep/cli/raw/v0.14.3/autocomplete/zsh_autocomplete
-	sha256sums = 9db8956443916016778ec2f1e9cf264e710afb67c447bfcd10a9c630db60b701
+	source = https://github.com/smallstep/cli/releases/download/v0.14.4/step_linux_0.14.4_amd64.tar.gz
+	source = https://github.com/smallstep/cli/raw/v0.14.4/autocomplete/bash_autocomplete
+	source = https://github.com/smallstep/cli/raw/v0.14.4/autocomplete/zsh_autocomplete
+	sha256sums = 583dd45d16a28f40f9d518bd84d1863ed849c70a4a1f4e89a793a48add107370
 	sha256sums = add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be
 	sha256sums = 3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = step-cli-bin
 	pkgdesc = A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.
-	pkgver = 0.14.5
+	pkgver = 0.14.6
 	pkgrel = 1
 	url = https://smallstep.com/cli
 	arch = x86_64
 	license = Apache
-	source = https://github.com/smallstep/cli/releases/download/v0.14.5/step_linux_0.14.5_amd64.tar.gz
-	source = https://github.com/smallstep/cli/raw/v0.14.5/autocomplete/bash_autocomplete
-	source = https://github.com/smallstep/cli/raw/v0.14.5/autocomplete/zsh_autocomplete
-	sha256sums = 4633754ad6b09c87e3e6b82ff01e80b3463059bf6aba6bf7dadc3d5da550dfe1
+	source = https://github.com/smallstep/cli/releases/download/v0.14.6/step_linux_0.14.6_amd64.tar.gz
+	source = https://github.com/smallstep/cli/raw/v0.14.6/autocomplete/bash_autocomplete
+	source = https://github.com/smallstep/cli/raw/v0.14.6/autocomplete/zsh_autocomplete
+	sha256sums = 4917800ee1cd99ec059dabbf2f40e9ba26ec4b05d70d19e58b526a11e962bde4
 	sha256sums = add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be
 	sha256sums = 3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18
 

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,16 +1,19 @@
 pkgbase = step-cli-bin
 	pkgdesc = A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc.
 	pkgver = 0.14.6
-	pkgrel = 1
+	pkgrel = 2
 	url = https://smallstep.com/cli
 	arch = x86_64
+	arch = aarch64
 	license = Apache
-	source = https://github.com/smallstep/cli/releases/download/v0.14.6/step_linux_0.14.6_amd64.tar.gz
 	source = https://github.com/smallstep/cli/raw/v0.14.6/autocomplete/bash_autocomplete
 	source = https://github.com/smallstep/cli/raw/v0.14.6/autocomplete/zsh_autocomplete
-	sha256sums = 4917800ee1cd99ec059dabbf2f40e9ba26ec4b05d70d19e58b526a11e962bde4
 	sha256sums = add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be
 	sha256sums = 3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18
+	source_x86_64 = https://github.com/smallstep/cli/releases/download/v0.14.6/step_linux_0.14.6_amd64.tar.gz
+	sha256sums_x86_64 = 4917800ee1cd99ec059dabbf2f40e9ba26ec4b05d70d19e58b526a11e962bde4
+	source_aarch64 = https://github.com/smallstep/cli/releases/download/v0.14.6/step_linux_0.14.6_arm64.tar.gz
+	sha256sums_aarch64 = a6cd472fa5eec9356270fbae3ed17b63fc3918901618ac91c5cc265cdca867f7
 
 pkgname = step-cli-bin
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Nazar Mishturak <nazarmx@gmail.com>
 _binname=step-cli
 pkgname=$_binname-bin
-pkgver=0.14.4
+pkgver=0.14.5
 pkgrel=1
 pkgdesc="A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc."
 arch=('x86_64')
@@ -14,7 +14,7 @@ source=("https://github.com/smallstep/cli/releases/download/v${pkgver}/step_linu
 	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/bash_autocomplete"
 	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/zsh_autocomplete")
 
-sha256sums=('583dd45d16a28f40f9d518bd84d1863ed849c70a4a1f4e89a793a48add107370'
+sha256sums=('4633754ad6b09c87e3e6b82ff01e80b3463059bf6aba6bf7dadc3d5da550dfe1'
             'add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be'
             '3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Nazar Mishturak <nazarmx@gmail.com>
 _binname=step-cli
 pkgname=$_binname-bin
-pkgver=0.14.3
+pkgver=0.14.4
 pkgrel=1
 pkgdesc="A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc."
 arch=('x86_64')
@@ -14,7 +14,7 @@ source=("https://github.com/smallstep/cli/releases/download/v${pkgver}/step_linu
 	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/bash_autocomplete"
 	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/zsh_autocomplete")
 
-sha256sums=('9db8956443916016778ec2f1e9cf264e710afb67c447bfcd10a9c630db60b701'
+sha256sums=('583dd45d16a28f40f9d518bd84d1863ed849c70a4a1f4e89a793a48add107370'
             'add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be'
             '3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18')
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,19 +4,21 @@
 _binname=step-cli
 pkgname=$_binname-bin
 pkgver=0.14.6
-pkgrel=1
+pkgrel=2
 pkgdesc="A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc."
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://smallstep.com/cli"
 license=('Apache')
 
-source=("https://github.com/smallstep/cli/releases/download/v${pkgver}/step_linux_${pkgver}_amd64.tar.gz"
-	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/bash_autocomplete"
+source=("https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/bash_autocomplete"
 	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/zsh_autocomplete")
+source_aarch64=("https://github.com/smallstep/cli/releases/download/v${pkgver}/step_linux_${pkgver}_arm64.tar.gz")
+source_x86_64=("https://github.com/smallstep/cli/releases/download/v${pkgver}/step_linux_${pkgver}_amd64.tar.gz")
 
-sha256sums=('4917800ee1cd99ec059dabbf2f40e9ba26ec4b05d70d19e58b526a11e962bde4'
-            'add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be'
+sha256sums=('add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be'
             '3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18')
+sha256sums_aarch64=("a6cd472fa5eec9356270fbae3ed17b63fc3918901618ac91c5cc265cdca867f7")
+sha256sums_x86_64=("4917800ee1cd99ec059dabbf2f40e9ba26ec4b05d70d19e58b526a11e962bde4")
 
 prepare() {
 	sed -i "s/step/${_binname}/g" "zsh_autocomplete"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,7 +3,7 @@
 # Maintainer: Nazar Mishturak <nazarmx@gmail.com>
 _binname=step-cli
 pkgname=$_binname-bin
-pkgver=0.14.5
+pkgver=0.14.6
 pkgrel=1
 pkgdesc="A zero trust swiss army knife for working with X509, OAuth, JWT, OATH OTP, etc."
 arch=('x86_64')
@@ -14,7 +14,7 @@ source=("https://github.com/smallstep/cli/releases/download/v${pkgver}/step_linu
 	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/bash_autocomplete"
 	"https://github.com/smallstep/cli/raw/v${pkgver}/autocomplete/zsh_autocomplete")
 
-sha256sums=('4633754ad6b09c87e3e6b82ff01e80b3463059bf6aba6bf7dadc3d5da550dfe1'
+sha256sums=('4917800ee1cd99ec059dabbf2f40e9ba26ec4b05d70d19e58b526a11e962bde4'
             'add3e078e394e265f6b6a3bf12af81cc7897410ae5e6a0d4ee7714a5b856a7be'
             '3e65c7f99484497e39d20eed3e4ceb4006e8db62dc9987f83a789bb575636e18')
 


### PR DESCRIPTION
Add support for installing the aarch64 build to PKGBUILD for Raspberry Pi users.

Context: https://github.com/smallstep/cli/issues/342

In theory the same approach could be used for arm7 builds (corresponds to armv7h in Arch), but I don't have a installation to test arm7 on so I only changed it for aarch64. 

I forked off the AUR mirror originally, which seems to be a couple of commits ahead of this github mirror, so probably you want to push the latest commits from the AUR repo to the github repo before merging this PR so they don't appear to be part of this PR.